### PR TITLE
Add NPM config to prevent tagging.

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+# We want CI to manage tagging
+git-tag-version=false


### PR DESCRIPTION
I've tested this by cloning the repo and running `npm version` with and without this `npmrc` config.

The config successfully prevents the git tag being added.