### PR TITLE
Fix receipt data

### DIFF
--- a/docs/model_DigiPayModel_DigitalPayPaymentResponse.d.ts.html
+++ b/docs/model_DigiPayModel_DigitalPayPaymentResponse.d.ts.html
@@ -172,7 +172,7 @@ export interface DigitalPayCreditCard extends DigitalPayPaymentInstrument {
 	stepUp?: CreditCardStepUp;
 
 	/** This object is only included in the response if it is enabled in the consumers API configuration. */
-	receiptData?: DigitalPayRecieptData;
+	receiptData?: DigitalPayCreditCardReceiptData;
 
 	/** This array is only included in the response if it is enabled in the consumers API configuration. */
 	extendedTransactionData?: DigitalPayExtendedTransactionData[];
@@ -215,7 +215,7 @@ export interface DigitalPayGiftCard extends DigitalPayPaymentInstrument {
 	stepUp?: CreditCardStepUp;
 
 	/** This object is only included in the response if it is enabled in the consumers API configuration. */
-	receiptData?: DigitalPayRecieptData;
+	receiptData?: DigitalPayGiftCardReceiptData;
 
 	/**
 	 * The external service code (from eg. Webpay).
@@ -234,7 +234,7 @@ export interface DigitalPayGiftCard extends DigitalPayPaymentInstrument {
 
 export interface DigitalPayPayPal extends DigitalPayPaymentInstrument {
 	/** This object is only included in the response if it is enabled in the consumers API configuration. */
-	receiptData?: DigitalPayRecieptData;
+	receiptData?: DigitalPayPayPalReceiptData;
 
 	/**
 	 * The external service code (from eg. Webpay).
@@ -278,7 +278,7 @@ export interface DigitalPayApplePay extends DigitalPayPaymentInstrument {
 	stepUp?: CreditCardStepUp;
 }
 
-export interface DigitalPayRecieptData {
+export interface DigitalPayCreditCardReceiptData {
 	/** The suffix (last 4 digits) of the credit card number used in the WebPay transaction. */
 	cardSuffix: string;
 
@@ -290,6 +290,19 @@ export interface DigitalPayRecieptData {
 
 	/** The year of the expiry date of the credit card. */
 	expiryYear: string;
+}
+
+export interface DigitalPayGiftCardReceiptData {
+	/** The suffix (last 4 digits) of the gift card number used in the WEX transaction. */
+	cardSuffix: string;
+}
+
+export interface DigitalPayPayPalReceiptData {
+	/** The Paypal email id. */
+	payPalId: string;
+
+	/** The Paypal customer id. */
+	customerId: string;
 }
 
 export interface DigitalPayExtendedTransactionData {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpay/sdk",
-  "version": "1.8.1",
+  "version": "1.8.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpay/sdk",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "Library that can facilitate JS applications accessing the WPay API.",
   "main": "src/index.js",
   "types": "types",

--- a/types/model/DigiPayModel/DigitalPayPaymentResponse.d.ts
+++ b/types/model/DigiPayModel/DigitalPayPaymentResponse.d.ts
@@ -85,7 +85,7 @@ export interface DigitalPayCreditCard extends DigitalPayPaymentInstrument {
 	stepUp?: CreditCardStepUp;
 
 	/** This object is only included in the response if it is enabled in the consumers API configuration. */
-	receiptData?: DigitalPayRecieptData;
+	receiptData?: DigitalPayCreditCardReceiptData;
 
 	/** This array is only included in the response if it is enabled in the consumers API configuration. */
 	extendedTransactionData?: DigitalPayExtendedTransactionData[];
@@ -128,7 +128,7 @@ export interface DigitalPayGiftCard extends DigitalPayPaymentInstrument {
 	stepUp?: CreditCardStepUp;
 
 	/** This object is only included in the response if it is enabled in the consumers API configuration. */
-	receiptData?: DigitalPayRecieptData;
+	receiptData?: DigitalPayGiftCardReceiptData;
 
 	/**
 	 * The external service code (from eg. Webpay).
@@ -147,7 +147,7 @@ export interface DigitalPayGiftCard extends DigitalPayPaymentInstrument {
 
 export interface DigitalPayPayPal extends DigitalPayPaymentInstrument {
 	/** This object is only included in the response if it is enabled in the consumers API configuration. */
-	receiptData?: DigitalPayRecieptData;
+	receiptData?: DigitalPayPayPalReceiptData;
 
 	/**
 	 * The external service code (from eg. Webpay).
@@ -191,7 +191,7 @@ export interface DigitalPayApplePay extends DigitalPayPaymentInstrument {
 	stepUp?: CreditCardStepUp;
 }
 
-export interface DigitalPayRecieptData {
+export interface DigitalPayCreditCardReceiptData {
 	/** The suffix (last 4 digits) of the credit card number used in the WebPay transaction. */
 	cardSuffix: string;
 
@@ -203,6 +203,19 @@ export interface DigitalPayRecieptData {
 
 	/** The year of the expiry date of the credit card. */
 	expiryYear: string;
+}
+
+export interface DigitalPayGiftCardReceiptData {
+	/** The suffix (last 4 digits) of the gift card number used in the WEX transaction. */
+	cardSuffix: string;
+}
+
+export interface DigitalPayPayPalReceiptData {
+	/** The Paypal email id. */
+	payPalId: string;
+
+	/** The Paypal customer id. */
+	customerId: string;
 }
 
 export interface DigitalPayExtendedTransactionData {


### PR DESCRIPTION
The types didn't match the API spec, as the default "credit card receipt data" was used for other instrument types.