### PR TITLE
Fix to a spelling mistake, Actual response and OAS spec has 'payPal'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpay/sdk",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpay/sdk",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Library that can facilitate JS applications accessing the WPay API.",
   "main": "src/index.js",
   "types": "types",

--- a/types/model/WalletManagementModel/MerchantProfileResponse.d.ts
+++ b/types/model/WalletManagementModel/MerchantProfileResponse.d.ts
@@ -28,7 +28,7 @@ export interface MerchantProfileResponse {
 		};
 
 		/** The presence of this object in the response indicates that paypal is an allowed payment method and instrument in the container for the relevant merchant. */
-		paypal: {
+		payPal: {
 			/** The paypal client token used for configuration and authorization of paypal transactions. */
 			clientToken: string;
 


### PR DESCRIPTION
A fix to a spelling mistake. Following is the actual response.
<img width="267" alt="Screen Shot 2022-05-02 at 7 04 55 am" src="https://user-images.githubusercontent.com/97861687/166164666-bf4b03ad-b6d4-4bbe-960a-bc8b2b93311c.png">
